### PR TITLE
Use correct NetOffice Outlook library

### DIFF
--- a/hagen.plugin.office.Test/hagen.plugin.office.Test.csproj
+++ b/hagen.plugin.office.Test/hagen.plugin.office.Test.csproj
@@ -13,19 +13,19 @@
       <HintPath>..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="NetOffice, Version=1.7.3.0, Culture=neutral, PublicKeyToken=acf636d62c39f8f5, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NetOffice.Core.1.7.4.4\lib\net45\NetOffice.dll</HintPath>
+    <Reference Include="NetOffice, Version=1.7.4.11, Culture=neutral, PublicKeyToken=297f57b43ae7c1de, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NetOfficeFw.Core.1.7.4.11\lib\net40\NetOffice.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="OfficeApi, Version=1.7.3.0, Culture=neutral, PublicKeyToken=7c1c3e9d16cace88, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NetOffice.Core.1.7.4.4\lib\net45\OfficeApi.dll</HintPath>
+    <Reference Include="OfficeApi, Version=1.7.4.11, Culture=neutral, PublicKeyToken=a39beb0835c43c8e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NetOfficeFw.Core.1.7.4.11\lib\net40\OfficeApi.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
-    <Reference Include="OutlookApi, Version=1.7.3.0, Culture=neutral, PublicKeyToken=865d86a9c321c488, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NetOffice.Outlook.1.7.4.4\lib\net45\OutlookApi.dll</HintPath>
+    <Reference Include="OutlookApi, Version=1.7.4.11, Culture=neutral, PublicKeyToken=b118031aaa1097f3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NetOfficeFw.Outlook.1.7.4.11\lib\net40\OutlookApi.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Sidi.Util, Version=14.3.0.0, Culture=neutral, PublicKeyToken=1e33c1a5eebc53e1, processorArchitecture=MSIL">
@@ -41,8 +41,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.XML" />
-    <Reference Include="VBIDEApi, Version=1.7.3.0, Culture=neutral, PublicKeyToken=a3637beacf571e8a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NetOffice.Core.1.7.4.4\lib\net45\VBIDEApi.dll</HintPath>
+    <Reference Include="VBIDEApi, Version=1.7.4.11, Culture=neutral, PublicKeyToken=931cec8882205047, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NetOfficeFw.Core.1.7.4.11\lib\net40\VBIDEApi.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="WindowsBase" />

--- a/hagen.plugin.office.Test/packages.config
+++ b/hagen.plugin.office.Test/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net461" />
-  <package id="NetOffice.Core" version="1.7.4.4" targetFramework="net47" />
-  <package id="NetOffice.Outlook" version="1.7.4.4" targetFramework="net47" />
+  <package id="NetOfficeFw.Core" version="1.7.4.11" targetFramework="net47" />
+  <package id="NetOfficeFw.Outlook" version="1.7.4.11" targetFramework="net47" />
   <package id="NUnit" version="3.12.0" targetFramework="net47" />
   <package id="NUnit.Console" version="3.10.0" targetFramework="net47" />
   <package id="NUnit.ConsoleRunner" version="3.10.0" targetFramework="net47" />

--- a/hagen.plugin.office/hagen.plugin.office.csproj
+++ b/hagen.plugin.office/hagen.plugin.office.csproj
@@ -56,16 +56,16 @@
     <Reference Include="Optional, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Optional.4.0.0\lib\net45\Optional.dll</HintPath>
     </Reference>
-    <Reference Include="NetOffice, Version=1.7.3.0, Culture=neutral, PublicKeyToken=acf636d62c39f8f5, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NetOffice.Core.1.7.4.4\lib\net45\NetOffice.dll</HintPath>
+    <Reference Include="NetOffice, Version=1.7.4.11, Culture=neutral, PublicKeyToken=297f57b43ae7c1de, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NetOfficeFw.Core.1.7.4.11\lib\net40\NetOffice.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
-    <Reference Include="OfficeApi, Version=1.7.3.0, Culture=neutral, PublicKeyToken=7c1c3e9d16cace88, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NetOffice.Core.1.7.4.4\lib\net45\OfficeApi.dll</HintPath>
+    <Reference Include="OfficeApi, Version=1.7.4.11, Culture=neutral, PublicKeyToken=a39beb0835c43c8e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NetOfficeFw.Core.1.7.4.11\lib\net40\OfficeApi.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
-    <Reference Include="OutlookApi, Version=1.7.3.0, Culture=neutral, PublicKeyToken=865d86a9c321c488, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NetOffice.Outlook.1.7.4.4\lib\net45\OutlookApi.dll</HintPath>
+    <Reference Include="OutlookApi, Version=1.7.4.11, Culture=neutral, PublicKeyToken=b118031aaa1097f3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NetOfficeFw.Outlook.1.7.4.11\lib\net40\OutlookApi.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Sidi.Util, Version=14.3.0.0, Culture=neutral, PublicKeyToken=1e33c1a5eebc53e1, processorArchitecture=MSIL">
@@ -87,8 +87,8 @@
     <Reference Include="System.XML" />
     <Reference Include="UIAutomationClient" />
     <Reference Include="UIAutomationTypes" />
-    <Reference Include="VBIDEApi, Version=1.7.3.0, Culture=neutral, PublicKeyToken=a3637beacf571e8a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NetOffice.Core.1.7.4.4\lib\net45\VBIDEApi.dll</HintPath>
+    <Reference Include="VBIDEApi, Version=1.7.4.11, Culture=neutral, PublicKeyToken=931cec8882205047, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NetOfficeFw.Core.1.7.4.11\lib\net40\VBIDEApi.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="WindowsBase" />

--- a/hagen.plugin.office/packages.config
+++ b/hagen.plugin.office/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net461" />
-  <package id="NetOffice.Core" version="1.7.4.4" targetFramework="net47" />
-  <package id="NetOffice.Outlook" version="1.7.4.4" targetFramework="net47" />
+  <package id="NetOfficeFw.Core" version="1.7.4.11" targetFramework="net47" />
+  <package id="NetOfficeFw.Outlook" version="1.7.4.11" targetFramework="net47" />
   <package id="sidi-util" version="14.3.0" targetFramework="net47" />
   <package id="Sprache" version="2.2.0" targetFramework="net461" />
   <package id="System.Data.SQLite.Core" version="1.0.112.0" targetFramework="net47" />


### PR DESCRIPTION
Switching from NetOffice to NetOfficeFw packages as they are more recent and the **NetOffice 1.7.4.4** is invalid release.

PS: When using nuget packages **NetOffice.Core** and **NetOffice.Outlook** in versions 1.7.4.4 or 1.7.4.11 you will in fact use NetOffice code from 1.7.3 release, because that package contains old assemblies.

By using **NetOfficeFw** packages, you will get the actual 1.7.4 source code and all the latest bugfixes (eg. with fix for https://github.com/NetOfficeFw/NetOffice/issues/223 which affects MS Outlook).